### PR TITLE
Remove dark mode

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,6 @@
     <div class="nav-top-text">
       <h1>SNU&nbsp;SAIT</h1>
       <button class="menu-toggle" aria-label="Toggle navigation">&#9776;</button>
-      <button class="theme-toggle" aria-label="Toggle theme">🌙</button>
     </div>
     <nav>
       <ul class="nav-menu">

--- a/professor.html
+++ b/professor.html
@@ -13,7 +13,6 @@
     <div class="nav-top-text">
       <h1>Professor</h1>
       <button class="menu-toggle" aria-label="Toggle navigation">&#9776;</button>
-      <button class="theme-toggle" aria-label="Toggle theme">🌙</button>
     </div>
     <nav>
       <ul class="nav-menu">

--- a/research.html
+++ b/research.html
@@ -13,7 +13,6 @@
     <div class="nav-top-text">
       <h1>Research</h1>
       <button class="menu-toggle" aria-label="Toggle navigation">&#9776;</button>
-      <button class="theme-toggle" aria-label="Toggle theme">🌙</button>
     </div>
     <nav>
       <ul class="nav-menu">

--- a/script.js
+++ b/script.js
@@ -8,27 +8,6 @@ document.addEventListener('DOMContentLoaded', () => {
     });
   }
 
-  // Dark mode toggle
-  const themeToggle = document.querySelector('.theme-toggle');
-  const rootElement = document.documentElement;
-  const storedTheme = localStorage.getItem('snu-sait-theme');
-  if (storedTheme) {
-    rootElement.setAttribute('data-theme', storedTheme);
-    // update button icon based on stored theme
-    if (themeToggle) {
-      themeToggle.textContent = storedTheme === 'dark' ? '☀️' : '🌙';
-    }
-  }
-  if (themeToggle) {
-    themeToggle.addEventListener('click', () => {
-      const currentTheme = rootElement.getAttribute('data-theme');
-      const newTheme = currentTheme === 'dark' ? 'light' : 'dark';
-      rootElement.setAttribute('data-theme', newTheme);
-      localStorage.setItem('snu-sait-theme', newTheme);
-      // update icon
-      themeToggle.textContent = newTheme === 'dark' ? '☀️' : '🌙';
-    });
-  }
 
   // Override navigation links to replace history entry instead of pushing a new one
   const navLinks = document.querySelectorAll('nav a[href]');

--- a/students.html
+++ b/students.html
@@ -13,7 +13,6 @@
     <div class="nav-top-text">
       <h1>Students</h1>
       <button class="menu-toggle" aria-label="Toggle navigation">&#9776;</button>
-      <button class="theme-toggle" aria-label="Toggle theme">🌙</button>
     </div>
     <nav>
       <ul class="nav-menu">

--- a/style.css
+++ b/style.css
@@ -10,14 +10,6 @@
   --text-color: #333;
 }
 
-/* Dark theme overrides */
-[data-theme='dark'] {
-  --primary-color: #222;
-  --secondary-color: #4ea1f3;
-  --background-color: #000;
-  --highlight-color: #1a1a1a;
-  --text-color: #f5f5f5;
-}
 
 
 /* Reset and base styles */
@@ -62,15 +54,6 @@ header {
   display: none;
 }
 
-/* Theme toggle button (sun/moon) */
-.theme-toggle {
-  background: none;
-  border: none;
-  color: white;
-  font-size: 1.5rem;
-  margin-left: 1rem;
-  cursor: pointer;
-}
 
 nav {
   max-width: 900px;


### PR DESCRIPTION
## Summary
- strip dark mode CSS variables and theme toggle styles
- remove dark mode JS logic
- drop theme toggle buttons from all pages

## Testing
- `node --version`

------
https://chatgpt.com/codex/tasks/task_e_6888cb5aaa54832abdbff550dc730860